### PR TITLE
chore: untrack svg files from lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,6 @@
 *.jpeg filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.tga filter=lfs diff=lfs merge=lfs -text
-*.svg filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text
 
 # Audio and Video formats


### PR DESCRIPTION
Updated LFS configuration to stop tracking SVG files, since they are text-based.